### PR TITLE
Update lock.yaml workflow to use secrets.GITHUB_TOKEN

### DIFF
--- a/github/workflows/lock.yaml
+++ b/github/workflows/lock.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: dessant/lock-threads@v5.0.1
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-inactive-days: "30"
           issue-lock-reason: ""
           pr-inactive-days: "1"


### PR DESCRIPTION
This should possibly solve the problem with secondary rate limits.